### PR TITLE
Update index on auction_timestamp table

### DIFF
--- a/priv/repo/migrations/20181220022827_update_auction_entry_timestamp_index.exs
+++ b/priv/repo/migrations/20181220022827_update_auction_entry_timestamp_index.exs
@@ -1,0 +1,8 @@
+defmodule Wow.Repo.Migrations.UpdateAuctionEntryTimestampIndex do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists index("auction_timestamp", [:auction_bid_id, :dump_timestamp])
+    create unique_index("auction_timestamp", [:auction_bid_id, "dump_timestamp DESC"])
+  end
+end


### PR DESCRIPTION
The index must be sorted, since it's a timestamp and we will often query using inequation (ex: dump_timestamp > '2018-11-18')